### PR TITLE
Use pkg.go.dev links instead of godoc.org

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -24,7 +24,7 @@
 <!--
                 <li {% if page.sectionid=='docs' %} class="active" {% endif %}><a href="{{ "/docs/home/" | prepend: site.baseurl }}">Docs</a></li>
 -->
-                <li><a href="https://godoc.org/github.com/go-kivik/kivik">GoDoc</a></li>
+                <li><a href="https://pkg.go.dev/github.com/go-kivik/kivik/v3">GoDoc</a></li>
                 <li><a href="https://github.com/go-kivik/kivik/wiki">Wiki</a></li>
                 <li><a href="https://github.com/go-kivik/kivik/issues">Bugs</a></li>
                 <li {% if page.sectionid=='blog' %} class="active" {% endif %}><a href="{{ site.posts.first.url | prepend: site.baseurl }}">News</a></li>

--- a/_posts/2020-02-09-v2-released.md
+++ b/_posts/2020-02-09-v2-released.md
@@ -26,32 +26,32 @@ A more extensive (but by no means exhaustive) list of changes follows.
 
 ### Breaking changes:
 
-- [New()](https://godoc.org/github.com/go-kivik/kivik#New) no longer takes a `context.Context` argument.
-- [Rows.Key()](https://godoc.org/github.com/go-kivik/kivik#Rows.Key) now returns the raw JSON for the key, rather than unquoting it.
+- [New()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#New) no longer takes a `context.Context` argument.
+- [Rows.Key()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Rows.Key) now returns the raw JSON for the key, rather than unquoting it.
 - The `kivik.Method*` and `kivik.Status*` constants were removed. Use `http.Method*` and `http.Status*` instead.
-- [Client.DB()](https://godoc.org/github.com/go-kivik/kivik#Client.DB) now defers errors until the next method call.
-- [DB.Get()](https://godoc.org/github.com/go-kivik/kivik#DB.Get) now defers errors until the next method call.
-- [Client.DBUpdates()](https://godoc.org/github.com/go-kivik/kivik#Client.DBUpdates) now takes a `context.Context` argument.
-- [DB.BulkDocs()](https://godoc.org/github.com/go-kivik/kivik#DB.BulkDocs) now takes a slice of documents, rather than an empty interface.
-- [DB.GetAttachmentMeta()](https://godoc.org/github.com/go-kivik/kivik#DB.GetAttachmentMeta) no longer takes a rev argument, which was redundant with options.
-- The [Attachment](https://godoc.org/github.com/go-kivik/kivik#Attachment) type is completely re-designed.
-- Replaced the `DB.Rev()` method with [DB.GetMeta()](https://godoc.org/github.com/go-kivik/kivik#DB.GetMeta).
+- [Client.DB()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.DB) now defers errors until the next method call.
+- [DB.Get()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.Get) now defers errors until the next method call.
+- [Client.DBUpdates()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.DBUpdates) now takes a `context.Context` argument.
+- [DB.BulkDocs()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.BulkDocs) now takes a slice of documents, rather than an empty interface.
+- [DB.GetAttachmentMeta()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.GetAttachmentMeta) no longer takes a rev argument, which was redundant with options.
+- The [Attachment](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Attachment) type is completely re-designed.
+- Replaced the `DB.Rev()` method with [DB.GetMeta()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.GetMeta).
 
 ### Additions:
 
-- Added the [DB.Err()](https://godoc.org/github.com/go-kivik/kivik#DB.Err) method to explicitly check a deferred error.
-- The [Attachment](https://godoc.org/github.com/go-kivik/kivik#Attachment) type now includes the RevPos and Digest fields, needed for replication.
+- Added the [DB.Err()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.Err) method to explicitly check a deferred error.
+- The [Attachment](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Attachment) type now includes the RevPos and Digest fields, needed for replication.
 - Kivik-generated errors now provide the [Unwrap](https://golang.org/pkg/errors/#Unwrap) method, introduced in Go 1.13.
-- Added the [DB.RevsDiff()](https://godoc.org/github.com/go-kivik/kivik#DB.RevsDiff) method, needed for replication.
-- Added the [Client.Config()](https://godoc.org/github.com/go-kivik/kivik#Client.Config), [Client.ConfigSection()](https://godoc.org/github.com/go-kivik/kivik#Client.ConfigSection), [Client.ConfigValue()](https://godoc.org/github.com/go-kivik/kivik#Client.ConfigValue), [Client.SetConfigValue()](https://godoc.org/github.com/go-kivik/kivik#Client.SetConfigValue), and [Client.DeleteConfigKey()](https://godoc.org/github.com/go-kivik/kivik#Client.DeleteConfigKey) methods, to manage server configuration.
-- Changes feed now reports the [ETag](https://godoc.org/github.com/go-kivik/kivik#Changes.ETag).
-- Added the [Client.Close()](https://godoc.org/github.com/go-kivik/kivik#Client.Close) and [DB.Close()](https://godoc.org/github.com/go-kivik/kivik#DB.Close) methods.
-- Added the [Client.ClusterSetup()](https://godoc.org/github.com/go-kivik/kivik#Client.ClusterSetup) and [Client.ClusterStatus()](https://godoc.org/github.com/go-kivik/kivik#Client.ClusterStatus) methods.
-- Added the [Client.Ping()](https://godoc.org/github.com/go-kivik/kivik#Client.Ping) method.
-- Added the [DB.BulkGet()](https://godoc.org/github.com/go-kivik/kivik#DB.BulkGet) method.
-- Added the [DB.LocalDocs()](https://godoc.org/github.com/go-kivik/kivik#DB.LocalDocs) and [DB.DesignDocs()](https://godoc.org/github.com/go-kivik/kivik#DB.DesignDocs) methods.
-- Added the [DB.Purge()](https://godoc.org/github.com/go-kivik/kivik#DB.Purge) method.
-- Added the [Client.DBsStats()](https://godoc.org/github.com/go-kivik/kivik#Client.DBsStats) method.
-- Added the experimental [AttachmentsIterator](https://godoc.org/github.com/go-kivik/kivik#AttachmentsIterator) type, for use with multi-part get requests.
+- Added the [DB.RevsDiff()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.RevsDiff) method, needed for replication.
+- Added the [Client.Config()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.Config), [Client.ConfigSection()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.ConfigSection), [Client.ConfigValue()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.ConfigValue), [Client.SetConfigValue()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.SetConfigValue), and [Client.DeleteConfigKey()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.DeleteConfigKey) methods, to manage server configuration.
+- Changes feed now reports the [ETag](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Changes.ETag).
+- Added the [Client.Close()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.Close) and [DB.Close()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.Close) methods.
+- Added the [Client.ClusterSetup()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.ClusterSetup) and [Client.ClusterStatus()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.ClusterStatus) methods.
+- Added the [Client.Ping()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.Ping) method.
+- Added the [DB.BulkGet()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.BulkGet) method.
+- Added the [DB.LocalDocs()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.LocalDocs) and [DB.DesignDocs()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.DesignDocs) methods.
+- Added the [DB.Purge()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#DB.Purge) method.
+- Added the [Client.DBsStats()](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#Client.DBsStats) method.
+- Added the experimental [AttachmentsIterator](https://https://pkg.go.dev/github.com/go-kivik/kivik/v3#AttachmentsIterator) type, for use with multi-part get requests.
 
 Kivik 3.0.0 should follow very shortly (within hours or days), and will be identical to Kivik 2.0.0, except that it will be configured for use with [Go modules](https://github.com/golang/go/wiki/Modules).

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ func main() {
     go get -u github.com/go-kivik/couchdb</pre>
             <p>
                 Then follow the <a href="https://github.com/go-kivik/kivik/wiki/Usage-Examples">Usage
-                Examples</a>, or read the <a href="http://godoc.org/github.com/go-kivik/kivik">GoDoc</a>,
+                Examples</a>, or read the <a href="https://pkg.go.dev/github.com/go-kivik/kivik/v3">GoDoc</a>,
                 or visit the project page on <a href="https://github.com/go-kivik/kivik">GitHub</a>.
             </p>
         </div>


### PR DESCRIPTION
since they seem to work better with modules

Relates to https://github.com/go-kivik/kivik/issues/445